### PR TITLE
Flip `car` and `cdr`

### DIFF
--- a/space_efficient_contracts_data.rkt
+++ b/space_efficient_contracts_data.rkt
@@ -134,8 +134,8 @@
          (filter (lambda (cp)
                    (not (implied-by-one? new-flat-list (car cp))))
                  (zip old-flat-list old-proj-list))])
-    (multi-flat/c (append new-proj-list (map car not-implied))
-                  (append new-flat-list (map cdr not-implied)))))
+    (multi-flat/c (append new-proj-list (map cdr not-implied))
+                  (append new-flat-list (map car not-implied)))))
 
 ; join two multi-ho/c 
 (define (join-multi-ho/c new-multi old-multi)


### PR DESCRIPTION
As is, the code puts `flat`s into `proj`s, which doesn't work.
Here's a failing test case:

```
(define i4 (ho/c (ho/c (flat/c integer?) (flat/c string?))
                 (ho/c (flat/c symbol?) (flat/c list?))))
(((guard i4 (lambda (x) x) "pos" "neg") add1) 'a)
```

This tries to apply a `flat/c` structure, which fails.
Also, those `flat`s don't seem to be used anywhere.
